### PR TITLE
Add support for temp_table_name override

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -212,7 +212,7 @@ Import options
 
 The ``from_csv`` manager method has the following arguments and keywords options. Returns the number of records added.
 
-.. method:: from_csv(csv_path_or_obj[, mapping=None, drop_constraints=True, drop_indexes=True, using=None, delimiter=',', null=None, force_not_null=None, force_null=None, encoding=None, static_mapping=None])
+.. method:: from_csv(csv_path_or_obj[, mapping=None, drop_constraints=True, drop_indexes=True, using=None, delimiter=',', null=None, force_not_null=None, force_null=None, encoding=None, static_mapping=None, temp_table_name=None])
 
 
 ===================  =========================================================
@@ -282,6 +282,12 @@ Keyword Argument       Description
                        for every row in the database by providing a dictionary
                        with the name of the columns as keys and the static
                        inputs as values.
+
+``temp_table_name``    Set the name of the temporary database table name used
+                       to stage data during import. If not provided, a name
+                       will be generated on the fly. The generated name is
+                       not guaranteed to be unique, which could negatively
+                       impact parallel import operations.
 =====================  =======================================================
 
 

--- a/postgres_copy/copy_from.py
+++ b/postgres_copy/copy_from.py
@@ -33,7 +33,8 @@ class CopyMapping(object):
         force_null=None,
         encoding=None,
         ignore_conflicts=False,
-        static_mapping=None
+        static_mapping=None,
+        temp_table_name=None
     ):
         # Set the required arguments
         self.model = model
@@ -90,7 +91,7 @@ class CopyMapping(object):
         self.validate_mapping()
 
         # Configure the name of our temporary table to COPY into
-        self.temp_table_name = "temp_%s" % self.model._meta.db_table
+        self.temp_table_name = temp_table_name or "temp_%s" % self.model._meta.db_table
 
     def save(self, silent=False, stream=sys.stdout):
         """


### PR DESCRIPTION
This enables clients that run more than one bulk import
operation concurrently to avoid table naming conflicts.