### PR TITLE
Add kwarg to setup query

### DIFF
--- a/postgres_copy/copy_to.py
+++ b/postgres_copy/copy_to.py
@@ -17,11 +17,11 @@ class SQLCopyToCompiler(SQLCompiler):
     """
     Custom SQL compiler for creating a COPY TO query (postgres backend only).
     """
-    def setup_query(self):
+    def setup_query(self, with_col_aliases=False):
         """
         Extend the default SQLCompiler.setup_query to add re-ordering of items in select.
         """
-        super(SQLCopyToCompiler, self).setup_query()
+        super(SQLCopyToCompiler, self).setup_query(with_col_aliases=with_col_aliases)
         if self.query.copy_to_fields:
             self.select = []
             for field in self.query.copy_to_fields:


### PR DESCRIPTION
In recent versions of Django, the `setup_query()` method of the `SQLCompiler` accepts a keyword `with_col_aliases`. As it currently stands, the method override in `SQLCopyToCompiler` doesn't accept any keywords. So if `with_col_aliases=X` is passed to `SQLCopyToCompiler`'s method, you'll get a `TypeError`. This PR should fix this, and I don't think it will break in older versions of Django. 

Tested with Django 4.2.1. I haven't tested an older version. I believe Django 4.0 lacks the `with_col_aliases` keyword if someone else is up for it.