### PR TITLE
Add checks for depreciated attributes.

### DIFF
--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -46,16 +46,16 @@ jobs:
     strategy:
       matrix:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        django: ['3.2', '4.2', '5.0']
+        django: ['3.2', '4.2', '5.1']
         exclude:
         - python: '3.7'
           django: '4.2'
         - python: '3.7'
-          django: '5.0'
+          django: '5.1'
         - python: '3.8'
-          django: '5.0'
+          django: '5.1'
         - python: '3.9'
-          django: '5.0'
+          django: '5.1'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -53,7 +53,8 @@ class ConstraintQuerySet(models.QuerySet):
         logger.debug(f"Dropping constraints from {self.model.__name__}")
         with connection.schema_editor() as schema_editor:
             # Remove any "unique_together" constraints
-            if self.model._meta.unique_together:
+            # NOTE: "unique_together" may be depreciated in the future
+            if getattr(self.model._meta, 'unique_together', False):
                 logger.debug(
                     "Dropping unique_together of {}".format(
                         self.model._meta.unique_together
@@ -76,11 +77,12 @@ class ConstraintQuerySet(models.QuerySet):
         """
         logger.debug(f"Dropping indexes from {self.model.__name__}")
         with connection.schema_editor() as schema_editor:
-            # Remove any "index_together" constraints
-            logger.debug(
-                f"Dropping index_together of {self.model._meta.index_together}"
-            )
-            if self.model._meta.index_together:
+            if getattr(self.model._meta, 'index_together', False):
+                # Remove any "index_together" constraints
+                # NOTE: "index_together has been removed from Django 5.1
+                logger.debug(
+                    f"Dropping index_together of {self.model._meta.index_together}"
+                )
                 args = (self.model, self.model._meta.index_together, ())
                 self.edit_schema(schema_editor, "alter_index_together", args)
 
@@ -99,7 +101,8 @@ class ConstraintQuerySet(models.QuerySet):
         logger.debug(f"Adding constraints to {self.model.__name__}")
         with connection.schema_editor() as schema_editor:
             # Add any "unique_together" contraints from the database
-            if self.model._meta.unique_together:
+            # NOTE: "unique_together" may be depreciated in the future
+            if getattr(self.model._meta, 'unique_together', False):
                 logger.debug(
                     "Adding unique_together of {}".format(
                         self.model._meta.unique_together
@@ -122,8 +125,9 @@ class ConstraintQuerySet(models.QuerySet):
         """
         logger.debug(f"Adding indexes to {self.model.__name__}")
         with connection.schema_editor() as schema_editor:
-            # Add any "index_together" contraints to the database.
-            if self.model._meta.index_together:
+            if getattr(self.model._meta, 'index_together', False):
+                # Add any "index_together" contraints to the database.
+                # NOTE: "index_together has been removed from Django 5.1
                 logger.debug(
                     "Restoring index_together of {}".format(
                         self.model._meta.index_together

--- a/postgres_copy/managers.py
+++ b/postgres_copy/managers.py
@@ -53,7 +53,7 @@ class ConstraintQuerySet(models.QuerySet):
         logger.debug(f"Dropping constraints from {self.model.__name__}")
         with connection.schema_editor() as schema_editor:
             # Remove any "unique_together" constraints
-            # NOTE: "unique_together" may be depreciated in the future
+            # NOTE: "unique_together" may be deprecated in the future
             if getattr(self.model._meta, 'unique_together', False):
                 logger.debug(
                     "Dropping unique_together of {}".format(
@@ -101,7 +101,7 @@ class ConstraintQuerySet(models.QuerySet):
         logger.debug(f"Adding constraints to {self.model.__name__}")
         with connection.schema_editor() as schema_editor:
             # Add any "unique_together" contraints from the database
-            # NOTE: "unique_together" may be depreciated in the future
+            # NOTE: "unique_together" may be deprecated in the future
             if getattr(self.model._meta, 'unique_together', False):
                 logger.debug(
                     "Adding unique_together of {}".format(

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,4 @@
+import django
 from django.db import models
 
 from postgres_copy import CopyManager, CopyMapping
@@ -17,7 +18,13 @@ class MockObject(models.Model):
     class Meta:
         app_label = "tests"
         unique_together = ("name", "number")
-        index_together = ("name", "number")
+
+    def __init__(self, *args, **kwargs):
+      super().__init__(*args, **kwargs)
+      if django.get_version() <= '5.1':
+        self._meta.index_together = ("name", "number")
+      else:
+        self._meta.indexes = [models.Index(fields=["name", "number"])]
 
     def copy_name_template(self):
         return 'upper("%(name)s")'


### PR DESCRIPTION
Fixes #198. Passed tests both for Django 4.2.14 and 5.1.1 (with the additional change that `MockObject.Meta.index_together` is replaced with `model.Index(fields=["name", "number"])`).